### PR TITLE
u-boot: Update RpI zero defconfig to support DTB.

### DIFF
--- a/recipes-bsp/u-boot/u-boot/0001-rpi_0_w-Add-configs-consistent-with-RpI3.patch
+++ b/recipes-bsp/u-boot/u-boot/0001-rpi_0_w-Add-configs-consistent-with-RpI3.patch
@@ -1,0 +1,40 @@
+From ee4328553b1a10d2686d60c7b184223b09d76cdc Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Sun, 7 Jan 2018 10:00:10 -0500
+Subject: [PATCH] rpi_0_w: Add configs consistent with RpI3
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ configs/rpi_0_w_defconfig | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
+index 092f378..623aad3 100644
+--- a/configs/rpi_0_w_defconfig
++++ b/configs/rpi_0_w_defconfig
+@@ -11,6 +11,10 @@ CONFIG_SYS_PROMPT="U-Boot> "
+ # CONFIG_CMD_FLASH is not set
+ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
++CONFIG_OF_EMBED=y
++CONFIG_ENV_FAT_INTERFACE="mmc"
++CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
++CONFIG_DM_KEYBOARD=y
+ # CONFIG_CMD_FPGA is not set
+ CONFIG_CMD_GPIO=y
+ CONFIG_DM_MMC=y
+@@ -19,8 +23,11 @@ CONFIG_MMC_SDHCI_BCM2835=y
+ CONFIG_DM_ETH=y
+ CONFIG_USB=y
+ CONFIG_DM_USB=y
++CONFIG_USB_DWC2=y
+ CONFIG_USB_STORAGE=y
+ CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_SMSC95XX=y
+ CONFIG_DM_VIDEO=y
+ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+-- 
+2.7.4
+

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/u-boot:"
 
 SRC_URI_append_rpi = " \
     file://0001-add-support-for-Raspberry-Pi-Zero-W.patch \
+    file://0001-rpi_0_w-Add-configs-consistent-with-RpI3.patch \
 "
 
 RDEPENDS_${PN}_append_rpi = " rpi-u-boot-scr"


### PR DESCRIPTION
This makes the defconfig more consistent with the RpI 3 and is needed
to get the RpI firmware provided DTB to function.

Signed-off-by: Drew Moseley <drew.moseley@northern.tech>

<!--
Please make sure you've read and understood our contributing guidelines.

For additional information on the contribution guidelines:
https://wiki.yoctoproject.org/wiki/Contribution_Guidelines#General_Information

If this PR fixes an issue, make sure your description includes "fixes #xxxx".

If this PR connects to an issue, make sure your description includes "connected to #xxxx".

Please provide the following information:
-->

**- What I did**

**- How I did it**
